### PR TITLE
Improvement for DataSet

### DIFF
--- a/DataSet.js
+++ b/DataSet.js
@@ -8,8 +8,8 @@
  */
 
 function DataSet(command, pageid, title, pathname, fileid) {
-  var taskerAdminUrl = ProcessWire.config.urls.admin + 'page/tasks',
-      taskerAdminApiUrl = taskerAdminUrl + '/api',
+  var taskerAdminUrl = ProcessWire.config.tasker.adminUrl,
+      taskerAdminApiUrl = ProcessWire.config.tasker.apiUrl,
       timeout = 150,
       unloading = false,
       progressLabel = $('#dataset_file_' + fileid + ' span'),

--- a/DataSet.module.php
+++ b/DataSet.module.php
@@ -89,6 +89,15 @@ pages:
       // append Javascript functions
       $this->config->scripts->add($this->config->urls->siteModules . 'DataSet/DataSet.js');
       $this->config->styles->add($this->config->urls->siteModules . 'DataSet/DataSet.css');
+
+      $taskerAdmin = wire('modules')->get('TaskerAdmin');
+      $this->adminUrl = $taskerAdmin->adminUrl;
+      // make this available for Javascript functions
+      $this->config->js('tasker', [
+        'adminUrl' => $this->adminUrl,
+        'apiUrl' => $this->adminUrl . 'api/',
+        'timeout' => 1000 * intval(ini_get('max_execution_time'))
+      ]);
     }
   }
 

--- a/DataSetConfig.php
+++ b/DataSetConfig.php
@@ -27,13 +27,15 @@ class DataSetConfig extends ModuleConfig {
     $fieldset = $this->wire('modules')->get('InputfieldFieldset');
     $fieldset->label = __('Requirements');
 
+    $f = $this->modules->get('InputfieldMarkup');
     if (!$this->modules->isInstalled('Tasker')) {
-      $f = $this->modules->get('InputfieldMarkup');
       $this->message('Tasker module is missing.', Notice::warning);
-      $f->value = '<p>Tasker module is missing. Install it before using this module.</p>';
-      $f->columnWidth = 50;
-      $fieldset->add($f);
+      $out = '<p>Tasker module is missing. Install it before using this module.</p>';
+    } else {
+      $out = "<p>Good! Tasker module is installed.</p>";
     }
+    $f->value = $out;
+    $fieldset->add($f);
 
     $inputfields->add($fieldset);
 


### PR DESCRIPTION
Replaced the hardcoded admin url in `DataSet.js` so if the end user move `Tasker Admin` (Tasks Management menu) under `Setup` or directly in the navbar, no error happen.

I also made a small correction to `Requirements` Inputfield config.